### PR TITLE
test: add pytest for setup_sql_profiler

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+addopts = -q
+testpaths = tests

--- a/tests/fixtures/__init__.py
+++ b/tests/fixtures/__init__.py
@@ -1,0 +1,1 @@
+# Fixtures package for test data.

--- a/tests/fixtures/sql_queries.py
+++ b/tests/fixtures/sql_queries.py
@@ -1,0 +1,3 @@
+SQL_QUERIES = [
+    "SELECT 1",
+]

--- a/tests/profiler/test_profiler.py
+++ b/tests/profiler/test_profiler.py
@@ -1,0 +1,20 @@
+from typing import Any
+
+from sqlalchemy import text
+from sqlalchemy.engine import Engine
+
+
+def test_profiler_captures_query(
+    engine: Engine,
+    sql_query: str,
+    queries: list[dict[str, Any]],
+) -> None:
+    """Profiler should intercept queries and store SQL and duration."""
+    with engine.connect() as conn:
+        conn.execute(text(sql_query))
+
+    assert len(queries) == 1
+
+    captured = queries[0]
+    assert sql_query in str(captured["sql"])
+    assert "duration" in captured


### PR DESCRIPTION
Fixes #6. Adds initial unit test for profiler instantiation and query capture.