### PR TITLE
Add per-endpoint database/schema/table trigger counters

### DIFF
--- a/src/fastapi_silk/middleware.py
+++ b/src/fastapi_silk/middleware.py
@@ -1,4 +1,6 @@
 import time
+from collections import Counter
+
 from fastapi import Request, Response
 from starlette.middleware.base import BaseHTTPMiddleware, RequestResponseEndpoint
 
@@ -23,6 +25,28 @@ class SQLDebugMiddleware(BaseHTTPMiddleware):
         queries = request_queries.get()
         db_time = sum(q["duration"] for q in queries)
 
+        database_hits: Counter[str] = Counter()
+        schema_hits: Counter[str] = Counter()
+        table_hits: Counter[str] = Counter()
+
+        for query in queries:
+            db_name = str(query.get("database") or "default")
+            database_hits[db_name] += 1
+
+            for ref in query.get("table_refs", []):
+                table_name = ref.get("table")
+                if not table_name:
+                    continue
+
+                schema_name = ref.get("schema")
+                if schema_name:
+                    schema_hits[str(schema_name)] += 1
+                    table_key = f"{schema_name}.{table_name}"
+                else:
+                    table_key = str(table_name)
+
+                table_hits[table_key] += 1
+
         response.headers["X-DB-Queries"] = str(len(queries))
         response.headers["X-DB-Time"] = f"{db_time:.4f}s"
         response.headers["X-Total-Time"] = f"{total_time:.4f}s"
@@ -46,6 +70,12 @@ class SQLDebugMiddleware(BaseHTTPMiddleware):
                     "queries": queries,
                     "db_time": round(db_time, 5),
                     "total_time": round(total_time, 5),
+                    "database_hits": dict(database_hits),
+                    "schema_hits": dict(schema_hits),
+                    "table_hits": dict(table_hits),
+                    "database_trigger_count": sum(database_hits.values()),
+                    "schema_trigger_count": sum(schema_hits.values()),
+                    "table_trigger_count": sum(table_hits.values()),
                 }
             )
         except Exception:

--- a/src/fastapi_silk/profiler.py
+++ b/src/fastapi_silk/profiler.py
@@ -1,12 +1,41 @@
+import re
 import time
 from typing import Any
+
 from sqlalchemy import Connection, ExecutionContext, event
 from sqlalchemy.engine import Engine
+
 from fastapi_silk.storage import request_queries
+
+_TABLE_PATTERN = re.compile(
+    r"\b(?:from|join|update|into|delete\s+from|truncate\s+table|alter\s+table)\s+([\w\"`\.]+)",
+    flags=re.IGNORECASE,
+)
+
+
+def _normalize_identifier(identifier: str) -> str:
+    cleaned = identifier.strip().strip(";")
+    parts = [p.strip().strip('"`[]') for p in cleaned.split(".") if p.strip()]
+    return ".".join(parts)
+
+
+def _extract_table_refs(statement: str) -> list[dict[str, str | None]]:
+    refs: list[dict[str, str | None]] = []
+    for match in _TABLE_PATTERN.finditer(statement):
+        normalized = _normalize_identifier(match.group(1))
+        if not normalized:
+            continue
+
+        if "." in normalized:
+            schema, table = normalized.rsplit(".", 1)
+        else:
+            schema, table = None, normalized
+
+        refs.append({"schema": schema, "table": table})
+    return refs
 
 
 def setup_sql_profiler(engine: Engine) -> None:
-
     @event.listens_for(engine, "before_cursor_execute")
     def before_cursor_execute(
         conn: Connection,
@@ -35,6 +64,8 @@ def setup_sql_profiler(engine: Engine) -> None:
                 "sql": statement,
                 "params": parameters,
                 "duration": round(total, 5),
+                "database": conn.engine.url.database,
+                "table_refs": _extract_table_refs(statement),
             }
         )
         request_queries.set(queries)

--- a/src/fastapi_silk/ui.py
+++ b/src/fastapi_silk/ui.py
@@ -186,7 +186,14 @@ async def ui_index() -> HTMLResponse:
               <div class="stat-value">${(r.queries || []).length}</div>
             </div>
           </div>
-          ${(r.queries || []).length > 0 ? `<div class="queries-count">${(r.queries || []).length} ${(r.queries || []).length === 1 ? 'query' : 'queries'}</div>` : ''}
+          <div class="queries-count">
+            DB triggers: ${r.database_trigger_count || 0} ·
+            Schemas: ${r.schema_trigger_count || 0} ·
+            Tables: ${r.table_trigger_count || 0}
+          </div>
+          ${(r.table_hits && Object.keys(r.table_hits).length > 0)
+            ? `<div class="queries-count">Tables hit: ${Object.entries(r.table_hits).map(([name, count]) => `${escapeHtml(name)} (${count})`).join(', ')}</div>`
+            : ''}
         </div>`;
       }
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+import unittest
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine, text
+from sqlalchemy.pool import StaticPool
+
+from fastapi_silk import SQLDebugMiddleware, setup_sql_profiler, silk_router
+from fastapi_silk.storage import recent_queries
+
+
+def build_app() -> FastAPI:
+    app = FastAPI()
+    engine = create_engine(
+        "sqlite://",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+
+    setup_sql_profiler(engine)
+    app.add_middleware(SQLDebugMiddleware)
+    app.include_router(silk_router)
+
+    with engine.begin() as conn:
+        conn.execute(
+            text("CREATE TABLE IF NOT EXISTS users (id INTEGER PRIMARY KEY, name TEXT)")
+        )
+        conn.execute(text("INSERT INTO users (name) VALUES ('alice')"))
+
+    @app.get("/with-query")
+    def with_query() -> dict[str, bool]:
+        with engine.connect() as conn:
+            conn.execute(text("SELECT id, name FROM users"))
+        return {"ok": True}
+
+    @app.get("/no-query")
+    def no_query() -> dict[str, bool]:
+        return {"ok": True}
+
+    return app
+
+
+class TestSQLProfilerIntegration(unittest.TestCase):
+    def setUp(self) -> None:
+        recent_queries.clear()
+
+    def test_headers_exist_and_count_queries(self) -> None:
+        app = build_app()
+
+        with TestClient(app) as client:
+            response = client.get("/with-query")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.headers["X-DB-Queries"], "1")
+        self.assertTrue(response.headers["X-DB-Time"].endswith("s"))
+        self.assertTrue(response.headers["X-Total-Time"].endswith("s"))
+
+    def test_request_state_is_reset_between_requests(self) -> None:
+        app = build_app()
+
+        with TestClient(app) as client:
+            first = client.get("/with-query")
+            second = client.get("/no-query")
+
+        self.assertEqual(first.status_code, 200)
+        self.assertEqual(second.status_code, 200)
+        self.assertEqual(first.headers["X-DB-Queries"], "1")
+        self.assertEqual(second.headers["X-DB-Queries"], "0")
+
+    def test_recent_api_includes_database_schema_table_trigger_counts(self) -> None:
+        app = build_app()
+
+        with TestClient(app) as client:
+            run_response = client.get("/with-query")
+            recent_response = client.get("/_silk/api/recent")
+
+        self.assertEqual(run_response.status_code, 200)
+        self.assertEqual(recent_response.status_code, 200)
+
+        payload = recent_response.json()
+        self.assertIn("recent", payload)
+        self.assertGreater(len(payload["recent"]), 0)
+
+        target_entry = next(
+            entry for entry in payload["recent"] if entry["path"] == "/with-query"
+        )
+
+        self.assertEqual(target_entry["database_trigger_count"], 1)
+        self.assertEqual(target_entry["schema_trigger_count"], 0)
+        self.assertEqual(target_entry["table_trigger_count"], 1)
+        self.assertEqual(target_entry["table_hits"].get("users"), 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_profiler_parsing.py
+++ b/tests/test_profiler_parsing.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+import unittest
+
+from fastapi_silk.profiler import _extract_table_refs
+
+
+class TestProfilerTableExtraction(unittest.TestCase):
+    def test_extracts_schema_and_table_for_join_queries(self) -> None:
+        statement = (
+            'SELECT * FROM "public"."users" u JOIN public.orders o ON o.user_id = u.id'
+        )
+
+        refs = _extract_table_refs(statement)
+
+        self.assertEqual(
+            refs,
+            [
+                {"schema": "public", "table": "users"},
+                {"schema": "public", "table": "orders"},
+            ],
+        )
+
+    def test_extracts_table_for_delete_update_insert(self) -> None:
+        delete_refs = _extract_table_refs("DELETE FROM logs WHERE id = 1")
+        update_refs = _extract_table_refs("UPDATE users SET name='x' WHERE id = 1")
+        insert_refs = _extract_table_refs("INSERT INTO users (name) VALUES ('x')")
+
+        self.assertEqual(delete_refs, [{"schema": None, "table": "logs"}])
+        self.assertEqual(update_refs, [{"schema": None, "table": "users"}])
+        self.assertEqual(insert_refs, [{"schema": None, "table": "users"}])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
Implements issue #2 by adding per-endpoint trigger counting for databases, schemas, and tables.

## What changed
- profiler now captures database and parsed 	able_refs for each SQL statement
- middleware aggregates trigger counts per request:
  - database_hits
  - schema_hits
  - 	able_hits
  - database_trigger_count
  - schema_trigger_count
  - 	able_trigger_count
- Silk UI now displays the new trigger counters and table hit breakdown
- Added tests:
  - integration coverage for recent API counters
  - unit coverage for SQL table-reference extraction

## Validation
- ruff check + format check
- mypy strict checks
- unittest suite (integration + parser tests)

Closes #2